### PR TITLE
Array and string offset access syntax with curly braces is deprecated

### DIFF
--- a/src/OAuth/SignatureMethod.php
+++ b/src/OAuth/SignatureMethod.php
@@ -45,7 +45,7 @@ abstract class SignatureMethod
     // Avoid a timing leak with a (hopefully) time insensitive compare
     $result = 0;
       for ($i = 0; $i < strlen($signature); $i++) {
-          $result |= ord($built{$i}) ^ ord($signature{$i});
+          $result |= ord($built[$i]) ^ ord($signature[$i]);
       }
 
       return $result == 0;


### PR DESCRIPTION
https://www.php.net/manual/en/migration74.deprecated.php

> The array and string offset access syntax using curly braces is deprecated. Use $var[$idx] instead of $var{$idx}.